### PR TITLE
🐛 fix: prevent interaction with previous command input execution fields

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -29,6 +29,13 @@ document.addEventListener("DOMContentLoaded", function () {
     if (event.key === "Enter") {
       event.preventDefault();
       const commandInput = event.target;
+
+      // Remove the input field and replace with span for preventing further input
+      const commandSpan = document.createElement("span");
+      commandSpan.className = "text-slate-50 text-sm md:text-base";
+      commandSpan.textContent = commandInput.value;
+      commandInput.replaceWith(commandSpan);
+
       const command = commandInput.value.trim().toLowerCase();
 
       // Create a new output element


### PR DESCRIPTION
### Description:
This pull request addresses and resolves issue #1 related to terminal behavior. Previously, the terminal allowed access to previous command input execution fields, potentially resulting in unexpected behavior and user confusion.

Fixes #1 

To fix this, the following changes have been implemented:

### Changes:
- Created a new `span` element.
- Replaced the previous `input` element with this new `span` element by setting previous command text inside it.